### PR TITLE
Reload configuration when settings are saved

### DIFF
--- a/script/Client.js
+++ b/script/Client.js
@@ -29,11 +29,20 @@ jQuery(document).ready(function () {
 	$("#video-container")
 		.addClass(positionHorizontalClass)
 		.addClass(positionVerticalClass);
+	$(".progress-container")
+		.addClass(positionHorizontalClass)
+		.addClass(positionVerticalClass);
 
 	if (!usePositionHorizontal) {
 		$("#video-container")
 			.removeClass(positionHorizontalClass);
 		$("#video-container video")
+			.css("left", settings.AbsolutePositionLeft !== 0 ? `${settings.AbsolutePositionLeft}px` : 'initial')
+			.css("right", settings.AbsolutePositionRight !== 0 ? `${settings.AbsolutePositionRight}px` : 'initial');
+
+		$(".progress-container")
+			.removeClass(positionHorizontalClass);
+		$(".progress-container")
 			.css("left", settings.AbsolutePositionLeft !== 0 ? `${settings.AbsolutePositionLeft}px` : 'initial')
 			.css("right", settings.AbsolutePositionRight !== 0 ? `${settings.AbsolutePositionRight}px` : 'initial');
 	}
@@ -44,6 +53,12 @@ jQuery(document).ready(function () {
 		$("#video-container video")
 			.css("top", settings.AbsolutePositionTop !== 0 ? `${settings.AbsolutePositionTop}px` : 'initial')
 			.css("bottom", settings.AbsolutePositionBottom !== 0 ? `${settings.AbsolutePositionBottom}px` : 'initial');
+		$(".progress-container")
+			.removeClass(positionVerticalClass);
+		$(".progress-container")
+			.css("top", settings.AbsolutePositionTop !== 0 ? `${settings.AbsolutePositionTop}px` : 'initial')
+			.css("bottom", settings.AbsolutePositionBottom !== 0 ? `${settings.AbsolutePositionBottom}px` : 'initial');
+
 	}
 
 	// max-width

--- a/script/Client.js
+++ b/script/Client.js
@@ -105,6 +105,7 @@ function videoLoaded() {
 			console.log("after entrance animation");
 			$(this).removeClass();
 		});
+	$("#video-container").removeClass("hidden");
 }
 
 function videoEnded() {
@@ -116,6 +117,8 @@ function videoEnded() {
 		.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function () {
 			console.log("after exit animation");
 			$(this).removeClass().addClass("hidden");
+
+			$("#video-container").addClass("hidden");
 		});
 }
 

--- a/script/Medal_StreamlabsSystem.py
+++ b/script/Medal_StreamlabsSystem.py
@@ -303,14 +303,10 @@ def Parse(parseString, userid, username, targetid, targetname, message):
 #---------------------------
 def Unload():
     Parent.Log(ScriptName, "Unload")
-    # try:
     Parent.Log(ScriptName, "Kill mohttpd Process")
-    # os.spawnl(os.P_WAIT, "taskkill", "/IM", "mohttpd.exe", "/F")
     stop = ProcessManager.Stop("mohttpd")
     Parent.Log(ScriptName, stop)
     Parent.Log(ScriptName, "Killed mohttpd Process")
-    # except Exception as e:
-    #     Parent.Log(ScriptName, str(e))
 
     if ClipWatcher is not None:
         ClipWatcher.ClipReady -= OnClipReady
@@ -327,16 +323,20 @@ def Unload():
 #   [Optional] ScriptToggled (Notifies you when a user disables your script or enables it)
 #---------------------------
 def ScriptToggled(state):
+    if state:
+        Init()
+    else:
+        Unload()
     return
 
 # ---------------------------------------
 # [Optional] Reload Settings (Called when a user clicks the Save Settings button in the Chatbot UI)
 # ---------------------------------------
-def ReloadSettings(jsonData):
-    """ Set newly saved data from UI after user saved settings. """
+def ReloadSettings(jsondata):
     Parent.Log(ScriptName, "Reload Settings")
     # Reload saved settings and validate values
-    ScriptSettings.Reload(jsonData)
+    Unload()
+    Init()
     return
 
 #---------------------------

--- a/script/Medal_StreamlabsSystem.py
+++ b/script/Medal_StreamlabsSystem.py
@@ -367,7 +367,6 @@ def OpenMedalInvite():
     os.startfile("https://medal.tv/invite/DarthMinos")
     return
 def OpenScriptUpdater():
-
     currentDir = os.path.realpath(os.path.dirname(__file__))
     chatbotRoot = os.path.realpath(os.path.join(currentDir, "../../../"))
     libsDir = os.path.join(currentDir, "Libs/")
@@ -398,7 +397,6 @@ def OpenScriptUpdater():
     except OSError as exc: # python >2.5
         raise
 
-    # os.system("./Libs/MedalOverlayUpdater.exe")
 def OpenOverlayPreview():
     os.startfile(os.path.realpath(os.path.join(os.path.dirname(__file__), "Overlay.html")))
 def PlayRandomVideo():

--- a/script/Overlay.html
+++ b/script/Overlay.html
@@ -44,10 +44,10 @@
 	</div>
 
 	<div class="progress-container hidden">
-		<div class="progress-bar"></div>
+		<div class="progress-bar"><div class="fill"></div></div>
 	</div>
 
-	<div class="video-container" id="video-container">
+	<div class="video-container hidden" id="video-container">
 		<video></video>
 	</div>
 

--- a/script/UI_Config.json
+++ b/script/UI_Config.json
@@ -11,7 +11,7 @@
 		"type": "checkbox",
 		"label": "Only Trigger off the Command",
 		"value": false,
-		"tooltip": "If enabled, videos triggered from pressing the hotkey will now playback on stream.",
+		"tooltip": "If enabled, videos triggered from pressing the hotkey will not playback on stream.",
 		"group": "General"
 	},
 

--- a/script/style.css
+++ b/script/style.css
@@ -57,6 +57,7 @@ body.bad-config {
 	display:none !important;
 }
 
+.progress-container,
 #video-container video {
 	padding: 0;
 	margin: 0;
@@ -68,32 +69,56 @@ body.bad-config {
 	bottom: initial;
 }
 
+.progress-container.center,
 #video-container.center video {
 	left: 40%;
 	right: initial;
 }
 
+.progress-container.left,
 #video-container.left video {
 	left: 0;
 	right: initial;
 }
 
+.progress-container.right,
 #video-container.right video {
 	right: 0;
 	left: initial;
 }
 
+.progress-container.middle,
 #video-container.middle video {
 	top: 40%;
 	bottom: initial;
 }
 
+.progress-container.top,
 #video-container.top video {
 	top: 0;
 	bottom: initial;
 }
 
+
+.progress-container.bottom,
 #video-container.bottom video {
 	bottom: 0;
 	top: initial;
+}
+
+.progress-container .progress-bar {
+	height: 200px;
+	width: 50px;
+	background-color: black;
+	padding: 4px;
+	display: inline-block;
+}
+
+.progress-container .progress-bar .fill {
+	background-color: red;
+	bottom: 0;
+	top: 50%;
+	left: 0;
+	right: 0;
+	position: absolute;
 }


### PR DESCRIPTION
The settings change the way things are configured and need to reload some things when the settings change. 

This fixes the event handler when the save button is clicked, and the module is "unloaded" and "reloaded" with the new settings.

This fixes #12 

There is also some html/css/js for an upcoming feature

Added some logic to remove the "visibility" flicker before the animation when the video loads